### PR TITLE
server/fetcher: implement `Fetcher`

### DIFF
--- a/server/fetcher/fetcher.go
+++ b/server/fetcher/fetcher.go
@@ -31,7 +31,7 @@ func New(client ethclient.Client, cp checkpoint.CheckpointReader, cfg *Config) *
 		eth:  client,
 		cp:   cp,
 		C:    make(chan *types.Block),
-		quit: make(chan struct{}, 1),
+		quit: make(chan struct{}),
 		cfg:  cfg,
 	}
 }
@@ -42,6 +42,7 @@ func (f *Fetcher) Run() {
 
 func (f *Fetcher) Stop() {
 	f.quit <- struct{}{}
+	f.quit = make(chan struct{})
 }
 
 // subscribe subscribes to events for new blocks. If the target

--- a/server/fetcher/fetcher.go
+++ b/server/fetcher/fetcher.go
@@ -1,6 +1,8 @@
 package fetcher
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/dbadoy/grinder/pkg/checkpoint"
@@ -35,8 +37,114 @@ func New(client ethclient.Client, cp checkpoint.CheckpointReader, cfg *Config) *
 }
 
 func (f *Fetcher) Run() {
+	go f.subscribe()
 }
 
 func (f *Fetcher) Stop() {
 	f.quit <- struct{}{}
+}
+
+// subscribe subscribes to events for new blocks. If the target
+// node does not support subscription, perform the polling method.
+func (f *Fetcher) subscribe() {
+	ch := make(chan *types.Block)
+
+	// In the subscription method, recovery does not occur until
+	// the next block creation event comes in.
+	sub, err := f.eth.SubscribeNewBlock(context.Background(), ch)
+	if err == nil {
+		for {
+			select {
+			case block := <-ch:
+				f.handle(block.NumberU64())
+
+			case <-f.quit:
+				sub.Unsubscribe()
+				return
+			}
+		}
+	}
+
+	close(ch)
+	f.polling(f.cfg.PollInterval)
+}
+
+// polling checks the block number at the given interval time.
+func (f *Fetcher) polling(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			latest, err := f.eth.GetLatestBlockNumber(context.Background())
+			if err != nil {
+				continue
+			}
+
+			f.handle(latest)
+
+		case <-f.quit:
+			return
+		}
+	}
+}
+
+// handle compares the checkpoint to the blockchain's latest
+// block number and performs a stateful action.
+//
+// 1. BN == Checkpoint
+//		- Synchronized
+//
+// 2. BN == Checkpoint + 1
+//		- Synchronized, new block detected
+//
+// 3. BN > Checkpoint
+// 		- Asynchronous, data recovery between Checkpoint and BN
+//
+// 4. BN < Checkpoint
+//		- Critical error ( need to consider reconfiguration)
+func (f *Fetcher) handle(latest uint64) {
+	if latest == f.cp.Checkpoint() {
+		return
+	}
+
+	if latest == f.cp.Checkpoint()+1 {
+		block, err := f.eth.BlockByNumber(context.Background(), latest)
+		if err != nil {
+			return
+		}
+		f.C <- block
+		return
+	}
+
+	f.recover(latest)
+}
+
+// recover fetches and sends the blocks between the checkpoint
+// and the given latest block number in order. If the process
+// of fetching a particular block number fails, it will retry.
+func (f *Fetcher) recover(latest uint64) {
+	if latest > f.cp.Checkpoint() {
+		for latest != f.cp.Checkpoint() {
+			// synchronization process is a blocking operation,
+			// so we check each time if the user has ended the
+			// polling.
+			select {
+			case <-f.quit:
+				return
+			default:
+			}
+
+			block, err := f.eth.BlockByNumber(context.Background(), f.cp.Checkpoint()+1)
+			if err != nil {
+				// Retry on failure until success.
+				continue
+			}
+
+			f.C <- block
+		}
+	} else {
+		panic(fmt.Errorf("occur critical error, blockchain latest: %d checkpoint: %d", latest, f.cp.Checkpoint()))
+	}
 }

--- a/server/fetcher/fetcher.go
+++ b/server/fetcher/fetcher.go
@@ -103,7 +103,7 @@ func (f *Fetcher) polling(interval time.Duration) {
 // 		- Asynchronous, data recovery between Checkpoint and BN
 //
 // 4. BN < Checkpoint
-//		- Critical error ( need to consider reconfiguration)
+//		- Critical error (need to consider reconfiguration)
 func (f *Fetcher) handle(latest uint64) {
 	if latest == f.cp.Checkpoint() {
 		return

--- a/server/fetcher/fetcher_test.go
+++ b/server/fetcher/fetcher_test.go
@@ -96,6 +96,7 @@ func TestPollingFetcherRealTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.SupportSubscribe = false
 
 	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
 	defer func() {
@@ -132,6 +133,7 @@ func TestPollingFetcherRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.SupportSubscribe = false
 
 	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
 	defer func() {

--- a/server/fetcher/fetcher_test.go
+++ b/server/fetcher/fetcher_test.go
@@ -1,1 +1,168 @@
 package fetcher
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dbadoy/grinder/pkg/checkpoint"
+	"github.com/dbadoy/grinder/pkg/ethclient/mock"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestSubscribeFetcherRealTime(t *testing.T) {
+	c, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.SupportSubscribe = true
+
+	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	fetcher := New(c, cp, &Config{PollInterval: 50 * time.Millisecond})
+
+	mined := make([]*types.Block, 0)
+	go func() {
+		for {
+			block := <-fetcher.C
+			if block.NumberU64() == fetcher.cp.Checkpoint()+1 {
+				mined = append(mined, block)
+				cp.Increase()
+			}
+		}
+	}()
+
+	fetcher.Run()
+
+	for i := 1; i <= 10; i++ {
+		c.Core().Commit()
+		time.Sleep(100 * time.Millisecond)
+
+		if len(mined) != i {
+			t.Fatalf("TestSubscribeFetcherRealTime, mined: %d want: %d", len(mined), i)
+		}
+	}
+}
+
+func TestSubscribeFetcherRecover(t *testing.T) {
+	c, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.SupportSubscribe = true
+
+	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	fetcher := New(c, cp, &Config{PollInterval: 50 * time.Millisecond})
+
+	mined := make([]*types.Block, 0)
+	go func() {
+		for {
+			block := <-fetcher.C
+			if block.NumberU64() == fetcher.cp.Checkpoint()+1 {
+				mined = append(mined, block)
+				cp.Increase()
+			}
+		}
+	}()
+
+	//
+	want := 10
+
+	for i := 1; i <= want; i++ {
+		c.Core().Commit()
+	}
+
+	fetcher.Run()
+
+	// If the fetcher starts, and the next block is not created,
+	// recover is not automatically performed.
+	c.Core().Commit()
+
+	time.Sleep(1 * time.Second)
+
+	if len(mined) != want+1 /* Include one block for recovery triggers */ {
+		t.Fatalf("TestSubscribeFetcherRecover, mined: %d want: %d", len(mined), want)
+	}
+}
+
+func TestPollingFetcherRealTime(t *testing.T) {
+	c, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	fetcher := New(c, cp, &Config{PollInterval: 50 * time.Millisecond})
+
+	mined := make([]*types.Block, 0)
+	go func() {
+		for {
+			block := <-fetcher.C
+			if block.NumberU64() == fetcher.cp.Checkpoint()+1 {
+				mined = append(mined, block)
+				cp.Increase()
+			}
+		}
+	}()
+
+	fetcher.Run()
+
+	for i := 1; i <= 10; i++ {
+		c.Core().Commit()
+		time.Sleep(100 * time.Millisecond)
+
+		if len(mined) != i {
+			t.Fatalf("TestFetcherRealTime, mined: %d want: %d", len(mined), i)
+		}
+	}
+}
+
+func TestPollingFetcherRecover(t *testing.T) {
+	c, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := checkpoint.New(checkpoint.DefaultBasePath, "fetcher")
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	fetcher := New(c, cp, &Config{PollInterval: 50 * time.Millisecond})
+
+	mined := make([]*types.Block, 0)
+	go func() {
+		for {
+			block := <-fetcher.C
+			if block.NumberU64() == fetcher.cp.Checkpoint()+1 {
+				mined = append(mined, block)
+				cp.Increase()
+			}
+		}
+	}()
+
+	want := 10
+
+	for i := 1; i <= want; i++ {
+		c.Core().Commit()
+	}
+
+	fetcher.Run()
+
+	time.Sleep(1 * time.Second)
+
+	if len(mined) != want {
+		t.Fatalf("TestFetcherRecover, mined: %d want: %d", len(mined), want)
+	}
+}

--- a/server/fetcher/fetcher_test.go
+++ b/server/fetcher/fetcher_test.go
@@ -72,7 +72,6 @@ func TestSubscribeFetcherRecover(t *testing.T) {
 		}
 	}()
 
-	//
 	want := 10
 
 	for i := 1; i <= want; i++ {

--- a/server/fetcher/fetcher_test.go
+++ b/server/fetcher/fetcher_test.go
@@ -38,7 +38,7 @@ func TestSubscribeFetcherRealTime(t *testing.T) {
 	fetcher.Run()
 
 	for i := 1; i <= 10; i++ {
-		c.Core().Commit()
+		c.Backend().Commit()
 		time.Sleep(100 * time.Millisecond)
 
 		if len(mined) != i {
@@ -75,14 +75,14 @@ func TestSubscribeFetcherRecover(t *testing.T) {
 	want := 10
 
 	for i := 1; i <= want; i++ {
-		c.Core().Commit()
+		c.Backend().Commit()
 	}
 
 	fetcher.Run()
 
 	// If the fetcher starts, and the next block is not created,
 	// recover is not automatically performed.
-	c.Core().Commit()
+	c.Backend().Commit()
 
 	time.Sleep(1 * time.Second)
 
@@ -118,7 +118,7 @@ func TestPollingFetcherRealTime(t *testing.T) {
 	fetcher.Run()
 
 	for i := 1; i <= 10; i++ {
-		c.Core().Commit()
+		c.Backend().Commit()
 		time.Sleep(100 * time.Millisecond)
 
 		if len(mined) != i {
@@ -154,7 +154,7 @@ func TestPollingFetcherRecover(t *testing.T) {
 	want := 10
 
 	for i := 1; i <= want; i++ {
-		c.Core().Commit()
+		c.Backend().Commit()
 	}
 
 	fetcher.Run()


### PR DESCRIPTION
Implement `Fetcher`.
- It supports two ways to fetch blocks: Subscribe and Polling. By default, it tries to Subscribe, and if the node doesn't support it, it performs the Polling method. 
- In addition to fetching the latest blocks, it also supports recovery. This is done by using `Checkpoint` provided by the caller.