### PR TITLE
server: impement API

### DIFF
--- a/server/dto/abi.go
+++ b/server/dto/abi.go
@@ -1,0 +1,43 @@
+package dto
+
+import "github.com/ethereum/go-ethereum/accounts/abi"
+
+type ABI struct {
+	MethodIDs  []string
+	MethodSigs []string
+	EventIDs   []string
+	EventSigs  []string
+}
+
+func (ABI) Index() string {
+	return "abis"
+}
+
+func PackABI(abi *abi.ABI) *ABI {
+	var (
+		methods = abi.Methods
+		events  = abi.Events
+
+		mids  = make([]string, len(methods))
+		msigs = make([]string, len(methods))
+		eids  = make([]string, len(methods))
+		esigs = make([]string, len(methods))
+	)
+
+	for _, method := range methods {
+		mids = append(mids, string(method.ID))
+		msigs = append(msigs, method.Sig)
+	}
+
+	for _, event := range events {
+		eids = append(eids, event.ID.Hex())
+		esigs = append(esigs, event.Sig)
+	}
+
+	return &ABI{
+		MethodIDs:  mids,
+		MethodSigs: msigs,
+		EventIDs:   eids,
+		EventSigs:  esigs,
+	}
+}

--- a/server/dto/dto.go
+++ b/server/dto/dto.go
@@ -6,5 +6,5 @@ var (
 	_ database.Data = (*Contract)(nil)
 	_ database.Data = (*ABI)(nil)
 
-	Indices = []string{Contract{}.Index(), ABI{}.Index()}
+	Indices = []string{new(Contract).Index(), new(ABI).Index()}
 )

--- a/server/dto/dto.go
+++ b/server/dto/dto.go
@@ -4,6 +4,7 @@ import "github.com/dbadoy/grinder/pkg/database"
 
 var (
 	_ database.Data = (*Contract)(nil)
+	_ database.Data = (*ABI)(nil)
 
-	Indices = []string{Contract{}.Index()}
+	Indices = []string{Contract{}.Index(), ABI{}.Index()}
 )

--- a/server/fetcher/fetcher.go
+++ b/server/fetcher/fetcher.go
@@ -2,12 +2,14 @@ package fetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/dbadoy/grinder/pkg/checkpoint"
 	"github.com/dbadoy/grinder/pkg/ethclient"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type Config struct {
@@ -79,6 +81,15 @@ func (f *Fetcher) subscribe() {
 				return
 			}
 		}
+	}
+
+	// Errors other than ErrNotificationsUnsupported may also
+	// occur. This is an abnormal behavior of the client itself,
+	// so there is no reason to keep it running.
+	//
+	// https://github.com/ethereum/go-ethereum/pull/25942
+	if !errors.Is(err, rpc.ErrNotificationsUnsupported) {
+		panic(fmt.Errorf("abnormal ethereum client in Fetcher: %v", err))
 	}
 
 	close(ch)

--- a/server/handler.go
+++ b/server/handler.go
@@ -102,7 +102,7 @@ func (s *Server) handleContract(hash common.Hash, ca common.Address) error {
 	return nil
 }
 
-func (s *Server) handleRequest(req Request) {
+func (s *Server) handleRequest(req request) {
 	var err error
 
 	switch req.Kind() {

--- a/server/handler.go
+++ b/server/handler.go
@@ -12,17 +12,17 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func (s *Server) handleBlock(block *types.Block) error {
-	return s.handleTransactions(block.Transactions())
-}
-
-func (s *Server) handleTransactions(txs types.Transactions) (err error) {
+func (s *Server) handleBlock(block *types.Block) (err error) {
 	defer func() {
 		if err != nil {
 			s.revert()
 		}
 	}()
 
+	return s.handleTransactions(block.Transactions())
+}
+
+func (s *Server) handleTransactions(txs types.Transactions) (err error) {
 	for _, tx := range txs {
 		if ca, err := contractAddress(tx); err == nil {
 			// Do handleContract if it is a deployment transaction.
@@ -112,7 +112,7 @@ func (s *Server) handleRequest(req Request) {
 
 	case contractRequestType:
 		contract := req.(*ContractRequest)
-		err = s.handleContract(common.Hash{}, contract.Address)
+		err = s.handleContract(common.Hash{} /* TODO */, contract.Address)
 
 	default:
 		err = errors.New("invalid request")
@@ -120,8 +120,9 @@ func (s *Server) handleRequest(req Request) {
 
 	if err != nil {
 		s.revert()
-		req.Errorc() <- err
 	}
+
+	req.Errorc() <- err
 }
 
 // revert performs a revert to a previous state if an

--- a/server/handler.go
+++ b/server/handler.go
@@ -103,6 +103,10 @@ func (s *Server) handleContract(hash common.Hash, ca common.Address) error {
 }
 
 func (s *Server) handleRequest(req request) {
+	if req.Errorc() == nil {
+		panic("bad Server.request: empty error channel")
+	}
+
 	var err error
 
 	switch req.Kind() {

--- a/server/handler.go
+++ b/server/handler.go
@@ -111,3 +111,21 @@ func (s *Server) handleContract(hash common.Hash, ca common.Address) error {
 
 	return nil
 }
+
+func (s *Server) handleRequest(req Request) {
+	var err error
+
+	switch req.Kind() {
+	case abiRequestType:
+		//
+	case contractRequestType:
+		//
+
+	default:
+		err = errors.New("invalid request")
+	}
+
+	if err != nil {
+		req.Errorc() <- err
+	}
+}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/dbadoy/grinder/pkg/checkpoint"
 	"github.com/dbadoy/grinder/pkg/database/memdb"
 	"github.com/dbadoy/grinder/pkg/ethclient/mock"
 	"github.com/dbadoy/grinder/server/cft"
 	"github.com/dbadoy/grinder/server/dto"
+	"github.com/dbadoy/grinder/server/fetcher"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -19,15 +21,18 @@ func TestHandleContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memdb := memdb.New()
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 24 * time.Hour})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
 
-	cp := checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
 	defer func() {
 		os.RemoveAll(checkpoint.DefaultBasePath)
 	}()
-
-	engine, _ := cft.NewSoloEngine(nil, memdb, cp)
-	s := &Server{eth: client, engine: engine, cfg: &Config{AllowProxyContract: false}}
 
 	// Remix Storage.sol
 	ca, err := mock.DeployContract(client, common.Hex2Bytes("608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100a1565b60405180910390f35b610073600480360381019061006e91906100ed565b61007e565b005b60008054905090565b8060008190555050565b6000819050919050565b61009b81610088565b82525050565b60006020820190506100b66000830184610092565b92915050565b600080fd5b6100ca81610088565b81146100d557600080fd5b50565b6000813590506100e7816100c1565b92915050565b600060208284031215610103576101026100bc565b5b6000610111848285016100d8565b9150509291505056fea2646970667358221220322c78243e61b783558509c9cc22cb8493dde6925aa5e89a08cdf6e22f279ef164736f6c63430008120033"))
@@ -58,5 +63,91 @@ func TestHandleContract(t *testing.T) {
 	}
 	if txs[0].Hash().Hex() != meta.TxHash {
 		t.Fatalf("TestProcessContract, want: %s got: %s", txs[0].Hash().Hex(), meta.TxHash)
+	}
+}
+
+func TestHandleABIRequest(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 24 * time.Hour})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	s.Run()
+	defer s.Stop()
+
+	input := &dto.ABI{
+		MethodIDs: []string{"0x000001", "0x000002"},
+		EventIDs:  []string{"0x00000a", "0x00000b"},
+	}
+
+	var (
+		name = "test"
+		errc = make(chan error, 1)
+	)
+
+	s.handleRequest(&ABIRequest{Name: name, ABI: input, errc: errc})
+	<-errc
+
+	abi := memdb.Get([]byte(name)).(*dto.ABI)
+	if len(abi.MethodIDs) != 2 || len(abi.EventIDs) != 2 {
+		t.Fatalf("TestHandleABIRequest, want: (MethodIDs 2 EventIDs 2) got: (MethodIDs %d EventIDs %d)", len(abi.MethodIDs), len(abi.EventIDs))
+	}
+}
+
+func TestHandleContractRequest(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 24 * time.Hour})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	s.Run()
+	defer s.Stop()
+
+	// Remix Storage.sol
+	ca, err := mock.DeployContract(client, common.Hex2Bytes("608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100a1565b60405180910390f35b610073600480360381019061006e91906100ed565b61007e565b005b60008054905090565b8060008190555050565b6000819050919050565b61009b81610088565b82525050565b60006020820190506100b66000830184610092565b92915050565b600080fd5b6100ca81610088565b81146100d557600080fd5b50565b6000813590506100e7816100c1565b92915050565b600060208284031215610103576101026100bc565b5b6000610111848285016100d8565b9150509291505056fea2646970667358221220322c78243e61b783558509c9cc22cb8493dde6925aa5e89a08cdf6e22f279ef164736f6c63430008120033"))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errc := make(chan error, 1)
+
+	input := &ContractRequest{
+		Address: ca,
+		errc:    errc,
+	}
+
+	s.handleRequest(input)
+	<-errc
+
+	contract := memdb.Get([]byte(ca.Hex())).(*dto.Contract)
+	if len(contract.Candidates) != 5 {
+		t.Fatalf("TestHandleContractRequest, want: 5 got: %d", len(contract.Candidates))
 	}
 }

--- a/server/request.go
+++ b/server/request.go
@@ -10,7 +10,11 @@ const (
 	contractRequestType
 )
 
-type Request interface {
+var (
+	_, _ request = (*ABIRequest)(nil), (*ContractRequest)(nil)
+)
+
+type request interface {
 	Errorc() chan<- error
 	Kind() byte
 }

--- a/server/request.go
+++ b/server/request.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"github.com/dbadoy/grinder/server/dto"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	abiRequestType = 0x01 + iota
+	contractRequestType
+)
+
+type Request interface {
+	Errorc() chan<- error
+	Kind() byte
+}
+
+type ABIRequest struct {
+	Name string
+	ABI  *dto.ABI
+	errc chan error
+}
+
+type ContractRequest struct {
+	Address common.Address
+	errc    chan error
+}
+
+func (a *ABIRequest) Errorc() chan<- error { return a.errc }
+func (ABIRequest) Kind() byte              { return abiRequestType }
+
+func (c *ContractRequest) Errorc() chan<- error { return c.errc }
+func (ContractRequest) Kind() byte              { return contractRequestType }

--- a/server/request.go
+++ b/server/request.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	abiRequestType = 0x01 + iota
+	abiRequestType = byte(1) + iota
 	contractRequestType
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	ErrServerTooBusy = errors.New("main loop is in a blocked state.")
+	ErrServerTooBusy = errors.New("main loop is in a blocked state")
 )
 
 type Server struct {

--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,7 @@ type Server struct {
 	journals []journalObject
 
 	// main loop
-	req  chan Request
+	req  chan request
 	quit chan struct{}
 
 	cfg *Config
@@ -39,7 +39,7 @@ func New(eth ethclient.Client, fetcher *fetcher.Fetcher, engine cft.Engine, cp c
 		eth:      eth,
 		fetcher:  fetcher,
 		journals: make([]journalObject, 0),
-		req:      make(chan Request),
+		req:      make(chan request),
 		quit:     make(chan struct{}),
 		cfg:      cfg,
 	}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -63,6 +63,7 @@ func (s *Server) EthClient() ethclient.Client {
 func (s *Server) Checkpoint() checkpoint.CheckpointReader {
 	return s.cp
 }
+
 func (s *Server) AddABI(req *ABIRequest) error {
 	req.errc = make(chan error)
 	select {

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,7 @@ func New(eth ethclient.Client, fetcher *fetcher.Fetcher, engine cft.Engine, cp c
 		eth:      eth,
 		fetcher:  fetcher,
 		journals: make([]journalObject, 0),
+		req:      make(chan Request),
 		quit:     make(chan struct{}),
 		cfg:      cfg,
 	}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -63,19 +63,6 @@ func (s *Server) EthClient() ethclient.Client {
 func (s *Server) Checkpoint() checkpoint.CheckpointReader {
 	return s.cp
 }
-
-func (s *Server) MustAddABI(req *ABIRequest) error {
-	req.errc = make(chan error)
-	s.req <- req
-	return <-req.errc
-}
-
-func (s *Server) MustAddContract(req *ContractRequest) error {
-	req.errc = make(chan error)
-	s.req <- req
-	return <-req.errc
-}
-
 func (s *Server) AddABI(req *ABIRequest) error {
 	req.errc = make(chan error)
 	select {
@@ -86,6 +73,12 @@ func (s *Server) AddABI(req *ABIRequest) error {
 	}
 }
 
+func (s *Server) AddABISync(req *ABIRequest) error {
+	req.errc = make(chan error)
+	s.req <- req
+	return <-req.errc
+}
+
 func (s *Server) AddContract(req *ContractRequest) error {
 	req.errc = make(chan error)
 	select {
@@ -94,6 +87,12 @@ func (s *Server) AddContract(req *ContractRequest) error {
 	default:
 		return ErrServerTooBusy
 	}
+}
+
+func (s *Server) AddContractSync(req *ContractRequest) error {
+	req.errc = make(chan error)
+	s.req <- req
+	return <-req.errc
 }
 
 func (s *Server) loop() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -64,7 +64,7 @@ func TestAddABI(t *testing.T) {
 	}
 }
 
-func TestMustAddABI(t *testing.T) {
+func TestAddABISync(t *testing.T) {
 	client, err := mock.New(mock.DefaultPrivateKey)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func TestAddContract(t *testing.T) {
 	}
 }
 
-func TestMustAddContract(t *testing.T) {
+func TestAddContractSync(t *testing.T) {
 	client, err := mock.New(mock.DefaultPrivateKey)
 	if err != nil {
 		t.Fatal(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -90,7 +90,7 @@ func TestMustAddABI(t *testing.T) {
 	}
 
 	go func() {
-		if err := s.MustAddABI(&ABIRequest{Name: "test", ABI: input}); err != nil {
+		if err := s.AddABISync(&ABIRequest{Name: "test", ABI: input}); err != nil {
 			panic(err)
 		}
 
@@ -180,7 +180,7 @@ func TestMustAddContract(t *testing.T) {
 	}
 
 	go func() {
-		if err := s.MustAddContract(&ContractRequest{Address: ca}); err != nil {
+		if err := s.AddContractSync(&ContractRequest{Address: ca}); err != nil {
 			panic(err)
 		}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dbadoy/grinder/pkg/checkpoint"
+	"github.com/dbadoy/grinder/pkg/database/memdb"
+	"github.com/dbadoy/grinder/pkg/ethclient/mock"
+	"github.com/dbadoy/grinder/server/cft"
+	"github.com/dbadoy/grinder/server/dto"
+	"github.com/dbadoy/grinder/server/fetcher"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestAddABI(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SupportSubscribe = false
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 1 * time.Second})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	input := &dto.ABI{
+		MethodIDs: []string{"0x000001", "0x000002"},
+		EventIDs:  []string{"0x00000a", "0x00000b"},
+	}
+
+	// It must fail because it's before the loop starts.
+	if err := s.AddABI(&ABIRequest{Name: "test", ABI: input}); err == nil {
+		t.Fatal("TestAddABI, want: failed got: success")
+	}
+
+	s.Run()
+	defer s.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+
+	if err := s.AddABI(&ABIRequest{Name: "test", ABI: input}); err != nil {
+		t.Fatal(err)
+	}
+
+	s.AddABI(&ABIRequest{Name: "test-1", ABI: input})
+	s.AddABI(&ABIRequest{Name: "test-2", ABI: input})
+	s.AddABI(&ABIRequest{Name: "test-3", ABI: input})
+
+	abi := memdb.Get([]byte("test")).(*dto.ABI)
+	if len(abi.MethodIDs) != 2 || len(abi.EventIDs) != 2 {
+		t.Fatalf("TestAddABI, want: (MethodIDs 2 EventIDs 2) got: (MethodIDs %d EventIDs %d)", len(abi.MethodIDs), len(abi.EventIDs))
+	}
+}
+
+func TestMustAddABI(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SupportSubscribe = false
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 1 * time.Second})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	input := &dto.ABI{
+		MethodIDs: []string{"0x000001", "0x000002"},
+		EventIDs:  []string{"0x00000a", "0x00000b"},
+	}
+
+	go func() {
+		if err := s.MustAddABI(&ABIRequest{Name: "test", ABI: input}); err != nil {
+			panic(err)
+		}
+
+		abi := memdb.Get([]byte("test")).(*dto.ABI)
+		if len(abi.MethodIDs) != 2 || len(abi.EventIDs) != 2 {
+			panic(fmt.Errorf("TestAddABI, want: (MethodIDs 2 EventIDs 2) got: (MethodIDs %d EventIDs %d)", len(abi.MethodIDs), len(abi.EventIDs)))
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	s.Run()
+	defer s.Stop()
+}
+
+func TestAddContract(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SupportSubscribe = false
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 1 * time.Second})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	// Remix Storage.sol
+	ca, err := mock.DeployContract(client, common.Hex2Bytes("608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100a1565b60405180910390f35b610073600480360381019061006e91906100ed565b61007e565b005b60008054905090565b8060008190555050565b6000819050919050565b61009b81610088565b82525050565b60006020820190506100b66000830184610092565b92915050565b600080fd5b6100ca81610088565b81146100d557600080fd5b50565b6000813590506100e7816100c1565b92915050565b600060208284031215610103576101026100bc565b5b6000610111848285016100d8565b9150509291505056fea2646970667358221220322c78243e61b783558509c9cc22cb8493dde6925aa5e89a08cdf6e22f279ef164736f6c63430008120033"))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// It must fail because it's before the loop starts.
+	if err := s.AddContract(&ContractRequest{Address: ca}); err == nil {
+		t.Fatal("TestAddContract, want: failed got: success")
+	}
+
+	s.Run()
+	defer s.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+
+	if err := s.AddContract(&ContractRequest{Address: ca}); err != nil {
+		t.Fatal(err)
+	}
+
+	contract := memdb.Get([]byte(ca.Hex())).(*dto.Contract)
+	if len(contract.Candidates) != 5 {
+		t.Fatalf("TestAddContract, want: 5 got: %d", len(contract.Candidates))
+	}
+}
+
+func TestMustAddContract(t *testing.T) {
+	client, err := mock.New(mock.DefaultPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SupportSubscribe = false
+
+	var (
+		cp        = checkpoint.New(checkpoint.DefaultBasePath, "handler")
+		memdb     = memdb.New()
+		fetcher   = fetcher.New(client, cp, &fetcher.Config{PollInterval: 1 * time.Second})
+		engine, _ = cft.NewSoloEngine(nil, memdb, cp)
+
+		s, _ = New(client, fetcher, engine, cp, &Config{AllowProxyContract: false})
+	)
+
+	defer func() {
+		os.RemoveAll(checkpoint.DefaultBasePath)
+	}()
+
+	// Remix Storage.sol
+	ca, err := mock.DeployContract(client, common.Hex2Bytes("608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100a1565b60405180910390f35b610073600480360381019061006e91906100ed565b61007e565b005b60008054905090565b8060008190555050565b6000819050919050565b61009b81610088565b82525050565b60006020820190506100b66000830184610092565b92915050565b600080fd5b6100ca81610088565b81146100d557600080fd5b50565b6000813590506100e7816100c1565b92915050565b600060208284031215610103576101026100bc565b5b6000610111848285016100d8565b9150509291505056fea2646970667358221220322c78243e61b783558509c9cc22cb8493dde6925aa5e89a08cdf6e22f279ef164736f6c63430008120033"))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		if err := s.MustAddContract(&ContractRequest{Address: ca}); err != nil {
+			panic(err)
+		}
+
+		contract := memdb.Get([]byte(ca.Hex())).(*dto.Contract)
+		if len(contract.Candidates) != 5 {
+			panic(fmt.Errorf("TestAddContract, want: 5 got: %d", len(contract.Candidates)))
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	s.Run()
+	defer s.Stop()
+}


### PR DESCRIPTION
Introduce a `Request` to make direct requests to the server, and add a channel for handle `Request` to the main loop. The Request API, which makes requests directly to the server, can only be called by an administrator. Users will make requests to the backend, which is connected to the DB.

For convenience, define a `dto.ABI` that stores commonly used contract interfaces.
- Server.AddABI, Server.AddABISync

